### PR TITLE
Fix conns table

### DIFF
--- a/data/implementations/connection_upgrades.json
+++ b/data/implementations/connection_upgrades.json
@@ -44,6 +44,11 @@
           "name": "Go",
           "status": "Missing",
           "url": ""
+        },
+        {
+          "name": "Rust",
+          "status": "Missing",
+          "url": ""
         }
       ]
     }


### PR DESCRIPTION
Small nit, but this PR fixes a rendering problem with the "Connection & Connection Upgrades" table.

<img width="807" alt="implementations_-_libp2p" src="https://user-images.githubusercontent.com/225111/45578604-6874d780-b837-11e8-8203-e2d4b3df3218.png">

@gnunicorn Are you ok with this line marked as "Missing" in rust-libp2p?  The basic problem is that not filling in the table data completely apparently breaks rendering of the table.  I had to pick some value, so I picked `Missing`.