### PR TITLE
Fix URL for go-libp2p-quic-transport

### DIFF
--- a/data/implementations/transports.json
+++ b/data/implementations/transports.json
@@ -43,7 +43,7 @@
         {
           "name": "Go",
           "status": "Unstable",
-          "url": "https://github.com/marten-seemann/libp2p-quic-transport"
+          "url": "https://github.com/libp2p/go-libp2p-quic-transport"
         },
         {
           "name": "Rust",


### PR DESCRIPTION
Removed old `gh/marten-seemen` URL and replaced with `gh/libp2p/go-libp2p-quic-transport`