### PR TITLE
add margin bottom to button

### DIFF
--- a/less/index.less
+++ b/less/index.less
@@ -138,6 +138,7 @@ article.a-modular-network-stack {
       }
       a {
         margin-top: 29px;
+        margin-bottom: 29px;
       }
       @media (max-width: 767px) {
         justify-content: space-around;


### PR DESCRIPTION
Recently viewed https://libp2p.io/ on a wide screen. The button was cut off. Made minor css adjustments.

Before:
![](https://i.imgur.com/od6yKuU.png)

After:
![](https://imgur.com/iQ7NsNO.png)

License: MIT
Signed-off-by: Leon Do leondo123@gmail.com