### PR TITLE
Update Rust's Record Store URL

### DIFF
--- a/data/implementations/record_stores.json
+++ b/data/implementations/record_stores.json
@@ -28,7 +28,7 @@
         {
           "name": "Rust",
           "status": "Unstable",
-          "url": "https://github.com/libp2p/rust-libp2p/tree/master/stores/datastore"
+          "url": "https://github.com/libp2p/rust-libp2p/tree/master/protocols/kad"
         }
       ]
     }


### PR DESCRIPTION
Resolves libp2p/website#87 to my best knowledge.

Please verify that this is the correct Url. I'm not familiar with the projects.