### PR TITLE
Add libp2p-circuit as NAT traversal option

### DIFF
--- a/data/implementations/nat_traversal.json
+++ b/data/implementations/nat_traversal.json
@@ -21,6 +21,26 @@
           "url": "https://github.com/libp2p/go-libp2p-nat"
         }
       ]
+    },
+    {
+      "id": "libp2p-circuit",
+      "langs": [
+        {
+          "name": "Browser JS",
+          "status": "Unstable",
+          "url": "https://github.com/libp2p/js-libp2p-circuit"
+        },
+        {
+          "name": "Node.js",
+          "status": "Unstable",
+          "url": "https://github.com/libp2p/js-libp2p-circuit"
+        },
+        {
+          "name": "Go",
+          "status": "Unstable",
+          "url": "https://github.com/libp2p/go-libp2p-circuit"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Added libp2p-circuit as NAT traversal option for js-libp2p.

Resolves #103.