### PR TITLE
data: Update Rust implementation entries

### DIFF
--- a/data/bundles.json
+++ b/data/bundles.json
@@ -283,8 +283,8 @@
         "id": "transport",
         "modules": [
           {
-            "id": "libp2p-tcp-transport",
-            "status": "Usable",
+            "id": "libp2p-tcp",
+            "status": "Done",
             "url": "https://github.com/libp2p/rust-libp2p/tree/master/transports/tcp"
           },
           {
@@ -300,11 +300,11 @@
           {
             "id": "libp2p-relay",
             "status": "Unstable",
-            "url": "https://github.com/libp2p/rust-libp2p/tree/master/transports/relay"
+            "url": "https://github.com/libp2p/rust-libp2p/pull/1838"
           },
           {
             "id": "libp2p-websocket",
-            "status": "Unstable",
+            "status": "Done",
             "url": "https://github.com/libp2p/rust-libp2p/tree/master/transports/websocket"
           }
         ]
@@ -314,19 +314,14 @@
         "modules": [
           {
             "id": "libp2p-yamux",
-            "status": "Usable",
+            "status": "Done",
             "url": "https://github.com/libp2p/rust-libp2p/tree/master/muxers/yamux"
           },
           {
             "id": "libp2p-mplex",
-            "status": "Usable",
+            "status": "Done",
             "url": "https://github.com/libp2p/rust-libp2p/tree/master/muxers/mplex"
           },
-          {
-            "id": "libp2p-secio",
-            "status": "Usable",
-            "url": "https://github.com/libp2p/rust-libp2p/tree/master/protocols/secio"
-          }
         ]
       },
       {
@@ -334,14 +329,9 @@
         "modules": [
           {
             "id": "libp2p-kad",
-            "status": "Usable",
+            "status": "Done",
             "url": "https://github.com/libp2p/rust-libp2p/tree/master/protocols/kad"
           },
-          {
-            "id": "libp2p-peerstore",
-            "status": "Usable",
-            "url": "https://github.com/libp2p/rust-libp2p/tree/master/stores/peerstore"
-          }
         ]
       },
       {
@@ -349,22 +339,22 @@
         "modules": [
           {
             "id": "libp2p-multistream-select",
-            "status": "Usable",
+            "status": "Done",
             "url": "https://github.com/libp2p/rust-libp2p/tree/master/misc/multistream-select"
           },
           {
             "id": "libp2p-ping",
-            "status": "Usable",
+            "status": "Done",
             "url": "https://github.com/libp2p/rust-libp2p/tree/master/protocols/ping"
           },
           {
             "id": "libp2p-identify",
-            "status": "Usable",
+            "status": "Done",
             "url": "https://github.com/libp2p/rust-libp2p/tree/master/protocols/identify"
           },
           {
             "id": "libp2p-dns",
-            "status": "Usable",
+            "status": "Done",
             "url": "https://github.com/libp2p/rust-libp2p/tree/master/transport/dns"
           },
           {
@@ -375,33 +365,28 @@
         ]
       },
       {
+        "id": "discovery",
+        "modules": [
+          {
+            "id": "libp2p-mdns",
+            "status": "Done",
+            "url": "https://github.com/libp2p/rust-libp2p/tree/master/protocols/mdns"
+          },
+        ]
+      }
+      {
         "id": "Utilities",
         "modules": [
           {
             "id": "multiaddr",
-            "status": "Usable",
+            "status": "Done",
             "url": "https://github.com/libp2p/rust-libp2p/tree/master/misc/multiaddr"
           },
           {
             "id": "multihash",
-            "status": "Usable",
+            "status": "Done",
             "url": "https://github.com/libp2p/rust-libp2p/tree/master/misc/multhash"
           },
-          {
-            "id": "rw-stream-sink",
-            "status": "Usable",
-            "url": "https://github.com/libp2p/rust-libp2p/tree/master/misc/rw-stream-sink"
-          },
-          {
-            "id": "libp2p-transport-timeout",
-            "status": "Usable",
-            "url": "https://github.com/libp2p/rust-libp2p/tree/master/transports/timeout"
-          },
-          {
-            "id": "libp2p-ratelimit",
-            "status": "Unstable",
-            "url": "https://github.com/libp2p/rust-libp2p/tree/master/transports/ratelimit"
-          }
         ]
       }
     ]

--- a/data/bundles.json
+++ b/data/bundles.json
@@ -321,7 +321,7 @@
             "id": "libp2p-mplex",
             "status": "Done",
             "url": "https://github.com/libp2p/rust-libp2p/tree/master/muxers/mplex"
-          },
+          }
         ]
       },
       {
@@ -331,7 +331,7 @@
             "id": "libp2p-kad",
             "status": "Done",
             "url": "https://github.com/libp2p/rust-libp2p/tree/master/protocols/kad"
-          },
+          }
         ]
       },
       {
@@ -371,9 +371,9 @@
             "id": "libp2p-mdns",
             "status": "Done",
             "url": "https://github.com/libp2p/rust-libp2p/tree/master/protocols/mdns"
-          },
+          }
         ]
-      }
+      },
       {
         "id": "Utilities",
         "modules": [
@@ -386,7 +386,7 @@
             "id": "multihash",
             "status": "Done",
             "url": "https://github.com/libp2p/rust-libp2p/tree/master/misc/multhash"
-          },
+          }
         ]
       }
     ]

--- a/data/implementations/discovery.json
+++ b/data/implementations/discovery.json
@@ -72,7 +72,7 @@
         },
         {
           "name": "Rust",
-          "status": "Usable",
+          "status": "Done",
           "url": "https://github.com/libp2p/rust-libp2p/tree/master/protocols/mdns"
         }
       ]

--- a/data/implementations/peer_routing.json
+++ b/data/implementations/peer_routing.json
@@ -22,7 +22,7 @@
         },
         {
           "name": "Rust",
-          "status": "Usable",
+          "status": "Done",
           "url": "https://github.com/libp2p/rust-libp2p/tree/master/protocols/kad"
         }
       ]

--- a/data/implementations/utils.json
+++ b/data/implementations/utils.json
@@ -72,7 +72,7 @@
         },
         {
           "name": "Rust",
-          "status": "Usable",
+          "status": "Done",
           "url": "https://github.com/libp2p/rust-libp2p/blob/master/core/src/peer_id.rs"
         }
       ]
@@ -97,8 +97,8 @@
         },
         {
           "name": "Rust",
-          "status": "Done",
-          "url": "https://github.com/libp2p/rust-libp2p/blob/master/peerstore/src/peer_info.rs"
+          "status": "Missing",
+          "url": ""
         }
       ]
     },


### PR DESCRIPTION
This pull request updates most entries in `/data` related to the libp2p Rust implementation.

**`status` updates**: I was not able to find a definition for `Done`. The changes below assume that `Done` means _used in production and to-the-best-of-our-knowledge compatible with the spec_. In case there is a definition a pointer would be very much appreciated. In case my assumption above is wrong, I am happy to make adjustments.