### PR TITLE
data/bundles: Tag rust-libp2p as "live"

### DIFF
--- a/data/bundles.json
+++ b/data/bundles.json
@@ -275,7 +275,7 @@
   {
     "id": "rust",
     "name": "Rust",
-    "status": "dev",
+    "status": "live",
     "image": "/img/logo_7.png",
     "github": "https://github.com/libp2p/rust-libp2p",
     "categories": [


### PR DESCRIPTION
rust-libp2p is used in production by many projects today [1] and
implements most major libp2p protocols. Thus it can be tagged as "live"
instead of "dev".

[1] https://github.com/libp2p/rust-libp2p/#notable-users