### PR TITLE
data/bundles: Tag Rust libp2p-relay as Usable

### DIFF
--- a/data/bundles.json
+++ b/data/bundles.json
@@ -299,8 +299,8 @@
           },
           {
             "id": "libp2p-relay",
-            "status": "Unstable",
-            "url": "https://github.com/libp2p/rust-libp2p/pull/1838"
+            "status": "Usable",
+            "url": "https://github.com/libp2p/rust-libp2p/tree/master/protocols/relay"
           },
           {
             "id": "libp2p-websocket",


### PR DESCRIPTION
With https://github.com/libp2p/rust-libp2p/pull/1838 merged rust-libp2p
supports the circuit relay v1 protocol. Tagged as "Usable" given that it
is still a bit bare bone.