### PR TITLE
implementations/discovery.json: Add rendezvous protocol

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -170,8 +170,6 @@
             </div>
         </div>
 
-        {{ partial "contributors.html" . }}
-
     </article>
 </main>
 

--- a/data/implementations/discovery.json
+++ b/data/implementations/discovery.json
@@ -76,6 +76,31 @@
           "url": "https://github.com/libp2p/rust-libp2p/tree/master/protocols/mdns"
         }
       ]
+    },
+    {
+      "id": "rendezvous",
+      "langs": [
+        {
+          "name": "Browser JS",
+          "status": "Unstable",
+          "url": "https://github.com/libp2p/js-libp2p-rendezvous/pull/6"
+        },
+        {
+          "name": "Node.js",
+          "status": "Unstable",
+          "url": "https://github.com/libp2p/js-libp2p-rendezvous/pull/6"
+        },
+        {
+          "name": "Go",
+          "status": "Unstable",
+          "url": "https://github.com/libp2p/go-libp2p-rendezvous/pull/1"
+        },
+        {
+          "name": "Rust",
+          "status": "Done",
+          "url": "https://github.com/libp2p/rust-libp2p/tree/master/protocols/rendezvous"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Reference the rendezvous protocol as a discovery protocol and link to the various (in-progress) implementations.