### PR TITLE
data/implementations: Update NAT traversal matrix

### DIFF
--- a/data/implementations/nat_traversal.json
+++ b/data/implementations/nat_traversal.json
@@ -3,7 +3,7 @@
   "title": "NAT Traversal",
   "libs": [
     {
-      "id": "libp2p-nat",
+      "id": "libp2p-circuit-relay-v2",
       "langs": [
         {
           "name": "Browser JS",
@@ -17,9 +17,64 @@
         },
         {
           "name": "Go",
+          "status": "Done",
+          "url": "https://github.com/libp2p/go-libp2p/tree/master/p2p/protocol/circuitv2"
+        },
+        {
+          "name": "Rust",
           "status": "Unstable",
-          "url": "https://github.com/libp2p/go-libp2p-nat"
+          "url": "https://github.com/libp2p/rust-libp2p/pull/2059"
         }
+      ]
+    },
+    {
+      "id": "libp2p-autonat",
+      "langs": [
+        {
+        "name": "Browser JS",
+        "status": "Missing",
+        "url": ""
+      },
+        {
+        "name": "Node.js",
+        "status": "Missing",
+        "url": ""
+      },
+        {
+        "name": "Go",
+        "status": "Done",
+        "url": "https://github.com/libp2p/go-libp2p-autonat"
+      },
+        {
+        "name": "Rust",
+        "status": "Unstable",
+        "url": "https://github.com/libp2p/rust-libp2p/pull/1672"
+      }
+      ]
+    },
+    {
+      "id": "libp2p-dcutr",
+      "langs": [
+        {
+        "name": "Browser JS",
+        "status": "Missing",
+        "url": ""
+      },
+        {
+        "name": "Node.js",
+        "status": "Missing",
+        "url": ""
+      },
+        {
+        "name": "Go",
+        "status": "Done",
+        "url": "https://github.com/libp2p/go-libp2p/tree/master/p2p/protocol/holepunch"
+      },
+        {
+        "name": "Rust",
+        "status": "Unstable",
+        "url": "https://github.com/libp2p/rust-libp2p/pull/2076"
+      }
       ]
     }
   ]


### PR DESCRIPTION
Updates the NAT traversal matrix on https://libp2p.io/implementations/ with the latest progress on _Project Flare_.

Useful in the future to point to the list of implementations from https://docs.libp2p.io

Helpful for https://github.com/libp2p/docs/issues/110.