### PR TITLE
content/index/: Change element.io to matrix.to

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -163,7 +163,7 @@
                 craft examples and tutorials.</p>
             <h6>Join Us</h6>
             <div class="buttons">
-              <a href="https://app.element.io/#/room/#libp2p:ipfs.io" target="_blank" class="btn-socials btn-matrix">MATRIX CHAT</a>
+              <a href="https://matrix.to/#/#libp2p:ipfs.io" target="_blank" class="btn-socials btn-matrix">MATRIX CHAT</a>
               <a href="https://discuss.libp2p.io" target="_blank" class="btn-socials btn-discuss">DISCUSSION FORUM</a>
               <a href="https://github.com/libp2p" target="_blank" class="btn-socials btn-github">GITHUB</a>
               <a href="https://twitter.com/libp2p" target="_blank" class="btn-socials btn-twitter">TWITTER</a>


### PR DESCRIPTION
We use matrix.to everywhere as it's more fair and better represent the whole matrix ecosystem.