### PR TITLE
fixed golang mdns link

### DIFF
--- a/data/bundles.json
+++ b/data/bundles.json
@@ -261,7 +261,7 @@
           {
             "id": "libp2p-mdns",
             "status": "Done",
-            "url": "https://github.com/libp2p/go-libp2p/blob/master/p2p/discovery/mdns.go"
+            "url": "https://github.com/libp2p/go-libp2p/blob/master/p2p/discovery/mdns/mdns.go"
           },
           {
             "id": "libp2p-railing",


### PR DESCRIPTION
This link was wrong

![image](https://user-images.githubusercontent.com/462087/152767410-bf093ec9-03e5-484a-a179-070eaeef2d1d.png)


Maybe its worth linking to godocs?