### PR TITLE
Removing Matrix link, since we're no longer using it.

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -163,7 +163,6 @@
                 craft examples and tutorials.</p>
             <h6>Join Us</h6>
             <div class="buttons">
-              <a href="https://matrix.to/#/#libp2p:ipfs.io" target="_blank" class="btn-socials btn-matrix">MATRIX CHAT</a>
               <a href="https://discuss.libp2p.io" target="_blank" class="btn-socials btn-discuss">DISCUSSION FORUM</a>
               <a href="https://github.com/libp2p" target="_blank" class="btn-socials btn-github">GITHUB</a>
               <a href="https://twitter.com/libp2p" target="_blank" class="btn-socials btn-twitter">TWITTER</a>


### PR DESCRIPTION
According to @BigLep, we're no longer using Matrix for Libp2p chatter (https://github.com/protocol/docs/issues/9#issuecomment-1035904341)