### PR TITLE
fix: correct implementations page for js-libp2p relay v2 and kad-dht

### DIFF
--- a/data/implementations/nat_traversal.json
+++ b/data/implementations/nat_traversal.json
@@ -50,8 +50,8 @@
           "url": "https://github.com/libp2p/rust-libp2p/tree/master/protocols/relay/src/v2"
         },
         "JavaScript": {
-          "status": "Done", 
-          "url": "https://github.com/libp2p/js-libp2p/tree/master/src/circuit"       
+          "status": "Missing",
+          "url": ""
         },
         "Nim": {
           "status": "Done",

--- a/data/implementations/peer_routing.json
+++ b/data/implementations/peer_routing.json
@@ -14,7 +14,7 @@
           "url": "https://github.com/libp2p/rust-libp2p/tree/master/protocols/kad"
         },
         "JavaScript": {
-          "status": "Unstable",
+          "status": "Usable",
           "url": "https://github.com/libp2p/js-libp2p-dht"
         },
         "Nim": {


### PR DESCRIPTION
Circuit Relay v2 is not yet supported in js-libp2p and js-libp2p-dht is not unstable