### PR TITLE
add: update videos and enhance media page (2022)

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -90,7 +90,7 @@
     </article>
 
     <article class="center publications-talks">
-        <h2 class="h1">Publications &amp; Talks</h2>
+        <h2 class="h1">Media</h2>
         <div class="wrap">
             <iframe width="620" height="350" src="https://www.youtube.com/embed/Sbd7odDFT1w" allowfullscreen></iframe>
         </div>

--- a/content/media.html
+++ b/content/media.html
@@ -59,12 +59,11 @@
             </div>
             <p>QUIC Deep Dive - Marten Seemann</p>
           </div>
-          <div>
-            <div class="item-video">
-              <div class="video-container">
-                <iframe src="https://www.youtube.com/embed/Dt42Ss6X_Vk" allowfullscreen></iframe>
-              </div>
-              <p>WebTransport Transport - Alex Potside</p>
+          <div class="item-video">
+            <div class="video-container">
+              <iframe src="https://www.youtube.com/embed/Dt42Ss6X_Vk" allowfullscreen></iframe>
+            </div>
+            <p>WebTransport Transport - Alex Potside</p>
           </div>
           <div>
             <div class="item-video">
@@ -115,12 +114,11 @@
             </div>
             <p>Intro to Lodestar - Cayman Nava</p>
           </div>
-          <div>
-            <div class="item-video">
-              <div class="video-container">
-                <iframe src="https://www.youtube.com/embed/0dKz_K-7eoI" allowfullscreen></iframe>
-              </div>
-              <p>The power of two choices - Petar Maymounkov</p>
+          <div class="item-video">
+            <div class="video-container">
+              <iframe src="https://www.youtube.com/embed/0dKz_K-7eoI" allowfullscreen></iframe>
+            </div>
+            <p>The power of two choices - Petar Maymounkov</p>
           </div>
         </div>
 

--- a/content/media.html
+++ b/content/media.html
@@ -12,7 +12,7 @@
   <main>
     <article class="center videos">
       <h1>Media</h1>
-      <div class="about-part">Talks, publications and demos.</div>
+      <div class="about-part">Talks, presentations, and demos.</div>
       <div class="triangle white"></div>
     </article>
     <article class="bg-gray">

--- a/content/media.html
+++ b/content/media.html
@@ -65,12 +65,11 @@
             </div>
             <p>WebTransport Transport - Alex Potside</p>
           </div>
-          <div>
-            <div class="item-video">
-              <div class="video-container">
-                <iframe src="https://www.youtube.com/embed/ZBIFFuakFHQ" allowfullscreen></iframe>
-              </div>
-              <p>Why WebRTC - Ryan Plauche & Max Inden</p>
+          <div class="item-video">
+            <div class="video-container">
+              <iframe src="https://www.youtube.com/embed/ZBIFFuakFHQ" allowfullscreen></iframe>
+            </div>
+            <p>Why WebRTC - Ryan Plauche & Max Inden</p>
           </div>
           <div class="item-video">
             <div class="video-container">

--- a/content/media.html
+++ b/content/media.html
@@ -21,61 +21,15 @@
         <div>
           <div class="item-video">
             <div class="video-container">
-              <iframe src="https://www.youtube.com/embed/Sbd7odDFT1w" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/J7ZWbpo2AZk" allowfullscreen></iframe>
             </div>
-            <p>May 2022 - Introduction to and State of libp2p - Max Inden</p>
+            <p>Introduction to and State of libp2p - Max Inden</p>
           </div>
           <div class="item-video">
             <div class="video-container">
               <iframe src="https://www.youtube.com/embed/jH9BkLTxhp8" allowfullscreen></iframe>
             </div>
-            <p>May 2022 - libp2p Project and Long Term View - Juan Benet</p>
-          </div>
-          <div class="item-video">
-            <div class="video-container">
-              <iframe src="https://www.youtube.com/embed/7OZLImVRvro" allowfullscreen></iframe>
-            </div>
-            <p>July 2021 - Intro to Libp2p - Max Inden</p>
-          </div>
-          <div class="item-video">
-            <div class="video-container">
-              <iframe src="https://www.youtube.com/embed/69h1zhIdCN0" allowfullscreen></iframe>
-            </div>
-            <p>July 2020 - Intro to decentralized messaging & libp2p - Jacob Heun</p>
-          </div>
-        </div>
-
-        <h2 class="subtitle">Technical Deep Dives</h2>
-        <div>
-          <div class="item-video">
-            <div class="video-container">
-              <iframe src="https://www.youtube.com/embed/aXYUw9tikaQ" allowfullscreen></iframe>
-            </div>
-            <p>Challenges in Browser Connectivity - libp2p’s future - Marten Seemann</p>
-          </div>
-          <div class="item-video">
-            <div class="video-container">
-              <iframe src="https://www.youtube.com/embed/MCEEMrIRks8" allowfullscreen></iframe>
-            </div>
-            <p>Hole punching with libp2p - Max Inden</p>
-          </div>
-          <div class="item-video">
-            <div class="video-container">
-              <iframe src="https://www.youtube.com/embed/6SyDP7xKqZk" allowfullscreen></iframe>
-            </div>
-            <p>QUIC Deep Dive - Marten Seemann</p>
-          </div>
-          <div class="item-video">
-            <div class="video-container">
-              <iframe src="https://www.youtube.com/embed/VEEEaf8B35w" allowfullscreen></iframe>
-            </div>
-            <p>Gossipsub, A gossip-based pubsub protocol - Yiannis Psaras</p>
-          </div>
-          <div class="item-video">
-            <div class="video-container">
-              <iframe src="https://www.youtube.com/embed/b8AZBVdrCC0" allowfullscreen></iframe>
-            </div>
-            <p>Demystifying Libp2p Gossipsub - Raúl Kripalani</p>
+            <p>libp2p Project and Long Term View - Juan Benet</p>
           </div>
           <div class="item-video">
             <div class="video-container">
@@ -85,27 +39,87 @@
           </div>
           <div class="item-video">
             <div class="video-container">
-              <iframe src="https://www.youtube.com/embed/HqSXFlCwgMY" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/69h1zhIdCN0" allowfullscreen></iframe>
             </div>
-            <p>Introduction to Rust Libp2p - Pierre Krieger</p>
+            <p>Intro to decentralized messaging & libp2p - Jacob Heun</p>
+          </div>
+        </div>
+
+        <h2 class="subtitle">Technical Deep Dives</h2>
+        <div>
+          <div class="item-video">
+            <div class="video-container">
+              <iframe src="https://www.youtube.com/embed/qG_1bYVtGO4" allowfullscreen></iframe>
+            </div>
+            <p>Browser connectivity state of the union - Marten Seemann</p>
           </div>
           <div class="item-video">
             <div class="video-container">
-              <iframe src="https://www.youtube.com/embed/eb-Mg7Kxv9w" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/6SyDP7xKqZk" allowfullscreen></iframe>
             </div>
-            <p>The libp2p Consensus Interface and the Raft Implementation - Hector Sanjuan</p>
+            <p>QUIC Deep Dive - Marten Seemann</p>
+          </div>
+          <div>
+            <div class="item-video">
+              <div class="video-container">
+                <iframe src="https://www.youtube.com/embed/Dt42Ss6X_Vk" allowfullscreen></iframe>
+              </div>
+              <p>WebTransport transport - Alex Potside</p>
+          </div>
+          <div>
+            <div class="item-video">
+              <div class="video-container">
+                <iframe src="https://www.youtube.com/embed/ZBIFFuakFHQ" allowfullscreen></iframe>
+              </div>
+              <p>Why WebRTC - Ryan Plauche & Max Inden</p>
           </div>
           <div class="item-video">
             <div class="video-container">
-              <iframe src="https://www.youtube.com/embed/zcWHamr5m_k" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/bzL7Y1wYth8" allowfullscreen></iframe>
             </div>
-            <p>The Life of a libp2p Connection - Jacob Heun</p>
+            <p>Decentralized NAT hole punching - Dennis Trautwein</p>
           </div>
           <div class="item-video">
             <div class="video-container">
-              <iframe src="https://www.youtube.com/embed/hyT91vdeZBk" allowfullscreen></iframe>
+              <iframe src="https://www.youtube.com/embed/b8AZBVdrCC0" allowfullscreen></iframe>
             </div>
-            <p>Go libp2p gorpc simple RPC on top of libp2p - Hector Sanjuan</p>
+            <p>Demystifying libp2p Gossipsub - Raúl Kripalani</p>
+          </div>
+          <div class="item-video">
+            <div class="video-container">
+              <iframe src="https://www.youtube.com/embed/T3QLhijHAwA" allowfullscreen></iframe>
+            </div>
+            <p>Formal analysis of GossipSub - Ankit Kumar</p>
+          </div>
+          <div class="item-video">
+            <div class="video-container">
+              <iframe src="https://www.youtube.com/embed/MvyyuMxsKqk" allowfullscreen></iframe>
+            </div>
+            <p>Tools for developing distributed protocols and apps - Pedro Akos Costa </p>
+          </div>
+          <div class="item-video">
+            <div class="video-container">
+              <iframe src="https://www.youtube.com/embed/jZrAnnFO-2c" allowfullscreen></iframe>
+            </div>
+            <p>DOS defense - Do’s and Don’ts - Max Inden </p>
+          </div>
+          <div class="item-video">
+            <div class="video-container">
+              <iframe src="https://www.youtube.com/embed/b2SkC4dYV-A" allowfullscreen></iframe>
+            </div>
+            <p>libp2p interoperability testing with Testground - Laurent Senta</p>
+          </div>
+          <div class="item-video">
+            <div class="video-container">
+              <iframe src="https://www.youtube.com/embed/1DStPz32k_4" allowfullscreen></iframe>
+            </div>
+            <p>Intro to Lodestar - Cayman Nava</p>
+          </div>
+          <div class="item-video">
+            <div class="video-container">
+              <iframe src="https://www.youtube.com/embed/0dKz_K-7eoI" allowfullscreen></iframe>
+            </div>
+            <p>The power of two choices - Petar Maymounkov</p>
           </div>
         </div>
 
@@ -121,30 +135,34 @@
             <div class="video-container">
               <iframe src="https://archive.org/embed/DWebSummit2016_Panel_Peer_to_Peer_Networks" width="300" height="200" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen></iframe>
             </div>
-            <p>Peer to Peer Networks at the Decentralised Web Summit</p>
+            <p>P2P networks at the Decentralised Web Summit</p>
+          </div>
+          <div class="item-video">
+            <div class="video-container">
+              <iframe src="https://www.youtube.com/embed/zcWHamr5m_k" allowfullscreen></iframe>
+            </div>
+            <p>The life of a libp2p connection - Jacob Heun</p>
+          </div>
+          <div class="item-video">
+            <div class="video-container">
+              <iframe src="https://www.youtube.com/embed/HqSXFlCwgMY" allowfullscreen></iframe>
+            </div>
+            <p>Introduction to rust-libp2p - Pierre Krieger</p>
+          </div>
+          <div class="item-video">
+            <div class="video-container">
+              <iframe src="https://www.youtube.com/embed/eb-Mg7Kxv9w" allowfullscreen></iframe>
+            </div>
+            <p>The libp2p consensus interface and the Raft implementation - Hector Sanjuan</p>
+          </div>
+          <div class="item-video">
+            <div class="video-container">
+              <iframe src="https://www.youtube.com/embed/hyT91vdeZBk" allowfullscreen></iframe>
+            </div>
+            <p>Go-libp2p-gorpc: simple RPC on top of libp2p - Hector Sanjuan</p>
           </div>
         </div>
       </section>
-    </article>
-
-    <article class="center articles">
-      <div class="wrap">
-        <h2 class="h1">Articles</h2>
-        <h3 class="subtitle">2016</h3>
-        <ul class="articles-list">
-          <li>
-            <a href="http://dapps.hatenablog.com/entry/2016/10/30/000000" class="link">Oct 30 - &lt;エンジニアに朗報&gt;イーサリアムとIPFSのコラボレーションによる次世代ライブラリとは</a>
-          </li>
-          <li>
-            <a href="https://github.com/libp2p/website/files/1196932/devcon2.pdf" class="link">Oct 27 - libp2p ❤ devp2p: Slides</a>
-          </li>
-          <li>
-            <a href="http://icwe2016.inf.usi.ch/program/tutorials/ipfs" class="link">Jun 9 - Distributed Web Applications with IPFS - 16th International Conference on Web Engineering (ICWE2016)</a>
-          </li>
-        </ul>
-        <div class="hr"></div>
-      </div>
-      <div class="triangle grey"></div>
     </article>
   </main>
 

--- a/content/media.html
+++ b/content/media.html
@@ -64,7 +64,7 @@
               <div class="video-container">
                 <iframe src="https://www.youtube.com/embed/Dt42Ss6X_Vk" allowfullscreen></iframe>
               </div>
-              <p>WebTransport transport - Alex Potside</p>
+              <p>WebTransport Transport - Alex Potside</p>
           </div>
           <div>
             <div class="item-video">
@@ -77,7 +77,7 @@
             <div class="video-container">
               <iframe src="https://www.youtube.com/embed/bzL7Y1wYth8" allowfullscreen></iframe>
             </div>
-            <p>Decentralized NAT hole punching - Dennis Trautwein</p>
+            <p>Decentralized NAT Hole Punching - Dennis Trautwein</p>
           </div>
           <div class="item-video">
             <div class="video-container">
@@ -89,7 +89,7 @@
             <div class="video-container">
               <iframe src="https://www.youtube.com/embed/T3QLhijHAwA" allowfullscreen></iframe>
             </div>
-            <p>Formal analysis of GossipSub - Ankit Kumar</p>
+            <p>Formal Analysis of GossipSub - Ankit Kumar</p>
           </div>
           <div class="item-video">
             <div class="video-container">
@@ -101,13 +101,13 @@
             <div class="video-container">
               <iframe src="https://www.youtube.com/embed/jZrAnnFO-2c" allowfullscreen></iframe>
             </div>
-            <p>DOS defense - Do’s and Don’ts - Max Inden </p>
+            <p>DOS Defense - Do’s and Don’ts - Max Inden </p>
           </div>
           <div class="item-video">
             <div class="video-container">
               <iframe src="https://www.youtube.com/embed/b2SkC4dYV-A" allowfullscreen></iframe>
             </div>
-            <p>libp2p interoperability testing with Testground - Laurent Senta</p>
+            <p>libp2p Interoperability Testing with Testground - Laurent Senta</p>
           </div>
           <div class="item-video">
             <div class="video-container">
@@ -127,21 +127,9 @@
         <div>
           <div class="item-video">
             <div class="video-container">
-              <iframe src="https://www.youtube.com/embed/HxueJbeMVG4" allowfullscreen></iframe>
-            </div>
-            <p>libp2p ❤ devp2p: IPFS and Ethereum Networking - David Dias</p>
-          </div>
-          <div class="item-video last-element">
-            <div class="video-container">
-              <iframe src="https://archive.org/embed/DWebSummit2016_Panel_Peer_to_Peer_Networks" width="300" height="200" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen></iframe>
-            </div>
-            <p>P2P networks at the Decentralised Web Summit</p>
-          </div>
-          <div class="item-video">
-            <div class="video-container">
               <iframe src="https://www.youtube.com/embed/zcWHamr5m_k" allowfullscreen></iframe>
             </div>
-            <p>The life of a libp2p connection - Jacob Heun</p>
+            <p>The Life of a libp2p Connection - Jacob Heun</p>
           </div>
           <div class="item-video">
             <div class="video-container">
@@ -153,13 +141,25 @@
             <div class="video-container">
               <iframe src="https://www.youtube.com/embed/eb-Mg7Kxv9w" allowfullscreen></iframe>
             </div>
-            <p>The libp2p consensus interface and the Raft implementation - Hector Sanjuan</p>
+            <p>The libp2p Consensus Interface and the Raft Implementation - Hector Sanjuan</p>
           </div>
           <div class="item-video">
             <div class="video-container">
               <iframe src="https://www.youtube.com/embed/hyT91vdeZBk" allowfullscreen></iframe>
             </div>
             <p>Go-libp2p-gorpc: simple RPC on top of libp2p - Hector Sanjuan</p>
+          </div>
+          <div class="item-video">
+            <div class="video-container">
+              <iframe src="https://www.youtube.com/embed/HxueJbeMVG4" allowfullscreen></iframe>
+            </div>
+            <p>libp2p ❤ devp2p: IPFS and Ethereum Networking - David Dias</p>
+          </div>
+          <div class="item-video last-element">
+            <div class="video-container">
+              <iframe src="https://archive.org/embed/DWebSummit2016_Panel_Peer_to_Peer_Networks" width="300" height="200" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen></iframe>
+            </div>
+            <p>P2P networks at the Decentralised Web Summit</p>
           </div>
         </div>
       </section>

--- a/content/media.html
+++ b/content/media.html
@@ -115,11 +115,12 @@
             </div>
             <p>Intro to Lodestar - Cayman Nava</p>
           </div>
-          <div class="item-video">
-            <div class="video-container">
-              <iframe src="https://www.youtube.com/embed/0dKz_K-7eoI" allowfullscreen></iframe>
-            </div>
-            <p>The power of two choices - Petar Maymounkov</p>
+          <div>
+            <div class="item-video">
+              <div class="video-container">
+                <iframe src="https://www.youtube.com/embed/0dKz_K-7eoI" allowfullscreen></iframe>
+              </div>
+              <p>The power of two choices - Petar Maymounkov</p>
           </div>
         </div>
 

--- a/content/media.html
+++ b/content/media.html
@@ -27,6 +27,12 @@
           </div>
           <div class="item-video">
             <div class="video-container">
+              <iframe src="https://www.youtube.com/embed/sG2j1EqVB0Q" allowfullscreen></iframe>
+            </div>
+            <p>PL EngRes libp2p Development and how you can be involved - Steve Loeppky</p>
+          </div>
+          <div class="item-video">
+            <div class="video-container">
               <iframe src="https://www.youtube.com/embed/jH9BkLTxhp8" allowfullscreen></iframe>
             </div>
             <p>libp2p Project and Long Term View - Juan Benet</p>
@@ -37,15 +43,9 @@
             </div>
             <p>Solving Distributed Networking Problems - Jacob Heun </p>
           </div>
-          <div class="item-video">
-            <div class="video-container">
-              <iframe src="https://www.youtube.com/embed/69h1zhIdCN0" allowfullscreen></iframe>
-            </div>
-            <p>Intro to decentralized messaging & libp2p - Jacob Heun</p>
-          </div>
         </div>
 
-        <h2 class="subtitle">Technical Deep Dives</h2>
+        <h2 class="subtitle">Browser Connectivity</h2>
         <div>
           <div class="item-video">
             <div class="video-container">
@@ -71,11 +71,21 @@
             </div>
             <p>Why WebRTC - Ryan Plauche & Max Inden</p>
           </div>
+        </div>
+
+        <h2 class="subtitle">Technical Deep Dives</h2>
+        <div>
           <div class="item-video">
             <div class="video-container">
               <iframe src="https://www.youtube.com/embed/bzL7Y1wYth8" allowfullscreen></iframe>
             </div>
             <p>Decentralized NAT Hole Punching - Dennis Trautwein</p>
+          </div>
+          <div class="item-video">
+            <div class="video-container">
+              <iframe src="https://www.youtube.com/embed/69h1zhIdCN0" allowfullscreen></iframe>
+            </div>
+            <p>Decentralized messaging & libp2p - Jacob Heun</p>
           </div>
           <div class="item-video">
             <div class="video-container">
@@ -109,15 +119,37 @@
           </div>
           <div class="item-video">
             <div class="video-container">
-              <iframe src="https://www.youtube.com/embed/1DStPz32k_4" allowfullscreen></iframe>
-            </div>
-            <p>Intro to Lodestar - Cayman Nava</p>
-          </div>
-          <div class="item-video">
-            <div class="video-container">
               <iframe src="https://www.youtube.com/embed/0dKz_K-7eoI" allowfullscreen></iframe>
             </div>
             <p>The power of two choices - Petar Maymounkov</p>
+          </div>
+        </div>
+
+        <h2 class="subtitle">Community</h2>
+        <div>
+          <div class="item-video">
+            <div class="video-container">
+              <iframe src="https://www.youtube.com/embed/Iv9VrLPloGI" allowfullscreen></iframe>
+            </div>
+            <p>libp2p in Nim - Tanguy</p>
+          </div>
+          <div class="item-video">
+            <div class="video-container">
+              <iframe src="https://www.youtube.com/embed/aIxmQKWUjNY" allowfullscreen></iframe>
+            </div>
+            <p>How Pyrsia is Using libp2p To Take Over the World - Elliott Frisch</p>
+          </div>
+          <div class="item-video">
+            <div class="video-container">
+              <iframe src="https://www.youtube.com/embed/baqWhUACUAg" allowfullscreen></iframe>
+            </div>
+            <p>Satellite.im and what we're doing with IPFS and js-libp2p - Drew Ewing</p>
+          </div>
+          <div class="item-video">
+            <div class="video-container">
+              <iframe src="https://www.youtube.com/embed/1DStPz32k_4" allowfullscreen></iframe>
+            </div>
+            <p>Intro to Lodestar - Cayman Nava</p>
           </div>
         </div>
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -9,10 +9,6 @@
     </div>
     <div>
       <nav>
-        <a href="/implementations" class="{{ if eq .URL "/implementations/" }}active{{end}}">Implementations</a>
-        <a href="/media" class="{{ if eq .URL "/media/" }}active{{end}}">Media</a>
-        <a href="{{ .Site.Params.specifications }}">Specifications</a>
-        <a href="/#community">Community</a>
         <a href="{{ .Site.Params.website}}">Website source</a>
       </nav>
       <small class="db f6 pt4">© <a class="link white hover-blue" href="https://protocol.ai/" target="_blank">Protocol Labs</a> | Except as <a class="link white hover-blue" href="https://protocol.ai/legal/">noted</a>, content licensed <a class="link white hover-blue" href="https://creativecommons.org/licenses/by/3.0/" target="_blank">CC-BY 3.0</a></small>


### PR DESCRIPTION
## Context

- resolves #157
- Adds the latest media available for libp2p, post libp2p day 2022
- General enhancements
- Removes the outdated articles section (this can re-added or added somewhere else with references to recent publications.)

## Latest preview

Please view the latest preview [here](https://bafybeieaflfspxwnxq7fwpfjxhjhvcwd2zopvtj265xfs75emro5ttroqy.on.fleek.co/media/).