### PR TITLE
fix(implementations): simultaneous icons for first matrix

### DIFF
--- a/content/implementations.html
+++ b/content/implementations.html
@@ -15,13 +15,12 @@
     <article class="center implementations">
       <h1>Implementations</h1>
       <div class="wrap">
-        <p>libp2p is composed of many modules and different parts. Here, overviews are available for all the different libraries, along with the 
+        <p>libp2p is composed of many modules and different parts. Here, overviews are available for all the different libraries, along with the
           status of each implementation. All sections use the same status legend and link to the implementation's source code.</p>
         <div class="links">
           <div class="active-link">
             <div class="copy-block">
               <div class="img">
-                <img width="10" src="/img/svg/transports.svg" alt="Transports">
               </div>
               <span>Transports</span>
             </div>


### PR DESCRIPTION
## Context

<img width="1021" alt="image" src="https://user-images.githubusercontent.com/25497083/209077338-2b7ceef0-0513-403a-a1e3-9cff50b4aeb9.png">
