### PR TITLE
docs: update implementation tables to add new js implementations

### DIFF
--- a/data/implementations/discovery.json
+++ b/data/implementations/discovery.json
@@ -14,7 +14,7 @@
         },
         "JavaScript": {
           "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p-railing"
+          "url": "https://github.com/libp2p/js-libp2p-bootstrap"
         },
         "Nim": {
           "status": "Missing"
@@ -50,8 +50,7 @@
           "url": "https://github.com/libp2p/rust-libp2p/tree/master/protocols/kad"
         },
         "JavaScript": {
-          "status": "Unstable",
-          "url": "https://github.com/libp2p/js-libp2p-random-walk"
+          "status": "Missing"
         },
         "Nim": {
           "status": "Missing"

--- a/data/implementations/nat_traversal.json
+++ b/data/implementations/nat_traversal.json
@@ -13,8 +13,7 @@
           "status": "Missing"
         },
         "JavaScript": {
-          "status": "Done", 
-          "url": "https://github.com/libp2p/js-libp2p-relay-server"       
+          "status": "Missing"
         },
         "Nim": {
           "status": "Done",
@@ -50,8 +49,8 @@
           "url": "https://github.com/libp2p/rust-libp2p/tree/master/protocols/relay/src/v2"
         },
         "JavaScript": {
-          "status": "Missing",
-          "url": ""
+          "status": "Done",
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/src/circuit-relay"
         },
         "Nim": {
           "status": "Done",
@@ -86,7 +85,8 @@
           "url": "https://github.com/libp2p/rust-libp2p/blob/master/protocols/autonat/"
         },
         "JavaScript": {
-          "status": "Missing"        
+          "status": "Done",
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/src/autonat"
         },
         "Nim": {
           "status": "Unstable",

--- a/data/implementations/others.json
+++ b/data/implementations/others.json
@@ -53,7 +53,7 @@
           "url": "https://github.com/libp2p/rust-libp2p/tree/master/protocols/gossipsub"
         },
         "JavaScript": {
-          "status": "Usable",
+          "status": "Done",
           "url": "https://github.com/ChainSafe/gossipsub-js"
         },
         "Nim": {

--- a/data/implementations/peer_routing.json
+++ b/data/implementations/peer_routing.json
@@ -14,8 +14,8 @@
           "url": "https://github.com/libp2p/rust-libp2p/tree/master/protocols/kad"
         },
         "JavaScript": {
-          "status": "Usable",
-          "url": "https://github.com/libp2p/js-libp2p-dht"
+          "status": "Done",
+          "url": "https://github.com/libp2p/js-libp2p-kad-dht"
         },
         "Nim": {
           "status": "Missing"

--- a/data/implementations/record_stores.json
+++ b/data/implementations/record_stores.json
@@ -14,7 +14,7 @@
           "url": "https://github.com/libp2p/rust-libp2p/tree/master/protocols/kad"
         },
         "JavaScript": {
-          "status": "Usable",
+          "status": "Done",
           "url": "https://github.com/libp2p/js-libp2p-record"
         },
         "Nim": {

--- a/data/implementations/stream_muxers.json
+++ b/data/implementations/stream_muxers.json
@@ -14,8 +14,8 @@
           "url": "https://github.com/libp2p/rust-libp2p/tree/master/muxers/yamux"
         },
         "JavaScript": {
-          "status": "Missing",
-          "url": ""
+          "status": "Done",
+          "url": "https://github.com/Chainsafe/js-libp2p-yamux"
         },
         "Nim": {
           "status": "Usable",

--- a/data/implementations/transports.json
+++ b/data/implementations/transports.json
@@ -127,7 +127,7 @@
           "status": "Missing"
         },
         "JavaScript": {
-          "status": "Unstable",
+          "status": "Usable",
           "url": "https://github.com/libp2p/js-libp2p-webtransport"
         },
         "Nim": {
@@ -189,10 +189,10 @@
       "id": "libp2p-webrtc-star",
       "langs": {
         "Go": {
-          "status": "Missing"        
+          "status": "Missing"
         },
         "Rust": {
-          "status": "Missing"        
+          "status": "Missing"
         },
         "JavaScript": {
           "status": "Done",
@@ -219,18 +219,17 @@
       }
     },
     {
-      "id": "libp2p-webrtc-direct",
+      "id": "libp2p-webrtc-private-to-private",
       "langs": {
         "Go": {
-          "status": "Unstable",
-          "url": "https://github.com/libp2p/go-libp2p-webrtc-direct"
+          "status": "Missing"
         },
         "Rust": {
           "status": "Missing"
         },
         "JavaScript": {
-          "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p-webrtc-direct"
+          "status": "Usable",
+          "url": "https://github.com/libp2p/js-libp2p-webrtc"
         },
         "Nim": {
           "status": "Missing"


### PR DESCRIPTION
Updates the status of various js implementations.

* Marks Circuit Relay v1 as missing since it's not shipped any more
* Marks Randomwalk missing as it's been removed
* Removes webrtc-direct
* Adds webrtc-private-to-private

I'm not sure what the distinction is between "Usable" and "Done" is in some places, I've marked the WebTransport transport as "Usable" instead of "Done" as there's no server listener yet.

I've marked KAD-DHT, GossipSub and to a lesser degree Yamux as "Done" since they're deployed by people and haven't changed in ages.