### PR TITLE
chore: update js-libp2p to introduce node support for private to private and fix links

### DIFF
--- a/data/implementations/discovery.json
+++ b/data/implementations/discovery.json
@@ -15,11 +15,11 @@
         },
         "JavaScript (Node)": {
           "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p-bootstrap"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/peer-discovery-bootstrap"
         },
         "JavaScript (Browser)": {
           "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p-bootstrap"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/peer-discovery-bootstrap"
         },
         "Nim": {
           "status": "Missing"
@@ -102,7 +102,7 @@
         },
         "JavaScript (Node)": {
           "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p-mdns"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/peer-discovery-mdns"
         },
         "JavaScript (Browser)": {
           "status": "Unimplementable"

--- a/data/implementations/nat_traversal.json
+++ b/data/implementations/nat_traversal.json
@@ -16,11 +16,11 @@
         },
         "JavaScript (Node)": {
           "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p/tree/master/src/circuit-relay"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/libp2p/src/circuit-relay"
         },
         "JavaScript (Browser)": {
           "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p/tree/master/src/circuit-relay"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/libp2p/src/circuit-relay"
         },
         "Nim": {
           "status": "Done",
@@ -60,11 +60,11 @@
         },
         "JavaScript (Node)": {
           "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p/tree/master/src/autonat"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/libp2p/src/autonat"
         },
         "JavaScript (Browser)": {
           "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p/tree/master/src/autonat"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/libp2p/src/autonat"
         },
         "Nim": {
           "status": "Unstable",
@@ -111,7 +111,7 @@
         },
         "JavaScript (Browser)": {
           "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p-webrtc"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/transport-webrtc"
         },
         "Nim": {
           "status": "Missing"

--- a/data/implementations/others.json
+++ b/data/implementations/others.json
@@ -15,11 +15,11 @@
         },
         "JavaScript (Node)": {
           "status": "Usable",
-          "url": "https://github.com/libp2p/js-libp2p-floodsub"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/pubsub-floodsub"
         },
         "JavaScript (Browser)": {
           "status": "Usable",
-          "url": "https://github.com/libp2p/js-libp2p-floodsub"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/pubsub-floodsub"
         },
         "Nim": {
           "status": "Done",

--- a/data/implementations/peer_routing.json
+++ b/data/implementations/peer_routing.json
@@ -16,11 +16,11 @@
         },
         "JavaScript (Node)": {
           "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p-kad-dht"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/kad-dht"
         },
         "JavaScript (Browser)": {
           "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p-kad-dht"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/kad-dht"
         },
         "Nim": {
           "status": "Missing"

--- a/data/implementations/record_stores.json
+++ b/data/implementations/record_stores.json
@@ -15,11 +15,11 @@
         },
         "JavaScript (Node)": {
           "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p-record"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/kad-dht/src/record"
         },
         "JavaScript (Browser)": {
           "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p-record"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/kad-dht/src/record"
         },
         "Nim": {
           "status": "Done",

--- a/data/implementations/stream_muxers.json
+++ b/data/implementations/stream_muxers.json
@@ -63,11 +63,11 @@
         },
         "JavaScript (Node)": {
           "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p-multiplex"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/stream-multiplexer-mplex"
         },
         "JavaScript (Browser)": {
           "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p-multiplex"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/stream-multiplexer-mplex"
         },
         "Nim": {
           "status": "Done",

--- a/data/implementations/transports.json
+++ b/data/implementations/transports.json
@@ -15,7 +15,7 @@
         },
         "JavaScript (Node)": {
           "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p-tcp"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/transport-tcp"
         },
         "JavaScript (Browser)": {
           "status": "Unimplementable"
@@ -104,11 +104,11 @@
         },
         "JavaScript (Node)": {
           "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p-websockets"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/transport-websockets"
         },
         "JavaScript (Browser)": {
           "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p-websockets"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/transport-websockets"
         },
         "Nim": {
           "status": "Done",
@@ -153,7 +153,7 @@
         },
         "JavaScript (Browser)": {
           "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p-websockets"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/transport-websockets"
         },
         "Nim": {
           "status": "Missing"
@@ -192,11 +192,11 @@
         },
         "JavaScript (Node)": {
           "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p-webrtc"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/transport-webrtc"
         },
         "JavaScript (Browser)": {
           "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p-webrtc"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/transport-webrtc"
         },
         "Nim": {
           "status": "Missing"
@@ -233,11 +233,12 @@
           "status": "Missing"
         },
         "JavaScript (Node)": {
-          "status": "Unimplementable"
+          "status": "Done",
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/transport-webrtc"
         },
         "JavaScript (Browser)": {
           "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p-webrtc"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/transport-webrtc"
         },
         "Nim": {
           "status": "Missing"

--- a/data/implementations/utils.json
+++ b/data/implementations/utils.json
@@ -16,11 +16,11 @@
         },
         "JavaScript (Node)": {
           "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p/tree/master/src/ping"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/libp2p/src/ping"
         },
         "JavaScript (Browser)": {
           "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p/tree/master/src/ping"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/libp2p/src/ping"
         },
         "Nim": {
           "status": "Done",
@@ -61,11 +61,11 @@
         },
         "JavaScript (Node)": {
           "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p-peer-id"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/peer-id"
         },
         "JavaScript (Browser)": {
           "status": "Done",
-          "url": "https://github.com/libp2p/js-libp2p-peer-id"
+          "url": "https://github.com/libp2p/js-libp2p/tree/master/packages/peer-id"
         },
         "Nim": {
           "status": "Done",


### PR DESCRIPTION
Fixes links after monorepo consolidation and adds https://github.com/libp2p/js-libp2p/pull/1905